### PR TITLE
Add minimal React quiz prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Node
+node_modules/
+dist/
+
+# Python
+__pycache__/
+*.pyc
+.env

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Learning Quiz AI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
     "vite": "^4.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,16 @@
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import Home from "./pages/Home";
+import Quiz from "./pages/Quiz";
+import Result from "./pages/Result";
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/quiz" element={<Quiz />} />
+        <Route path="/result" element={<Result />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,27 @@
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+
+export default function Home() {
+  const [url, setUrl] = useState("");
+  const navigate = useNavigate();
+
+  const handleStart = () => {
+    navigate("/quiz");
+  };
+
+  return (
+    <div style={{ maxWidth: 400, margin: "0 auto", padding: 20 }}>
+      <h1>📚 Learn from any URL</h1>
+      <input
+        type="text"
+        placeholder="https://example.com/article"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        style={{ width: "100%", padding: "8px" }}
+      />
+      <button onClick={handleStart} style={{ marginTop: 10 }}>
+        Generate
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/Quiz.tsx
+++ b/frontend/src/pages/Quiz.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { quiz } from "../quizData";
+
+export default function Quiz() {
+  const [step, setStep] = useState(0);
+  const [answers, setAnswers] = useState<number[]>([]);
+  const [choice, setChoice] = useState<number | null>(null);
+  const navigate = useNavigate();
+
+  const question = quiz[step];
+
+  const handleNext = () => {
+    if (choice === null) return;
+    const newAnswers = [...answers, choice];
+    setAnswers(newAnswers);
+    setChoice(null);
+    if (step + 1 < quiz.length) {
+      setStep(step + 1);
+    } else {
+      navigate("/result", { state: { answers: newAnswers } });
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 600, margin: "0 auto", padding: 20 }}>
+      <h2>
+        Question {step + 1} of {quiz.length}
+      </h2>
+      <p>{question.question}</p>
+      <ul style={{ listStyle: "none", padding: 0 }}>
+        {question.options.map((opt, idx) => (
+          <li key={idx} style={{ marginBottom: "8px" }}>
+            <label>
+              <input
+                type="radio"
+                name="option"
+                checked={choice === idx}
+                onChange={() => setChoice(idx)}
+                style={{ marginRight: "4px" }}
+              />
+              {opt}
+            </label>
+          </li>
+        ))}
+      </ul>
+      <button onClick={handleNext}>Next →</button>
+    </div>
+  );
+}

--- a/frontend/src/pages/Result.tsx
+++ b/frontend/src/pages/Result.tsx
@@ -1,0 +1,38 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { quiz } from "../quizData";
+
+interface LocationState {
+  answers: number[];
+}
+
+export default function Result() {
+  const navigate = useNavigate();
+  const { state } = useLocation() as { state: LocationState };
+  const answers = state?.answers || [];
+
+  const score = answers.reduce(
+    (acc, ans, idx) => (ans === quiz[idx].answer ? acc + 1 : acc),
+    0,
+  );
+
+  return (
+    <div style={{ maxWidth: 600, margin: "0 auto", padding: 20 }}>
+      <h1>
+        🎉 You scored {score} out of {quiz.length}!
+      </h1>
+      <ul>
+        {quiz.map((q, idx) => (
+          <li key={idx} style={{ marginBottom: "12px" }}>
+            <p>{q.question}</p>
+            <p>
+              {answers[idx] === q.answer ? "✔️" : "❌"} Correct:{" "}
+              {q.options[q.answer]} — Your answer:{" "}
+              {answers[idx] !== undefined ? q.options[answers[idx]] : "N/A"}
+            </p>
+          </li>
+        ))}
+      </ul>
+      <button onClick={() => navigate("/")}>Try Another URL</button>
+    </div>
+  );
+}

--- a/frontend/src/quizData.ts
+++ b/frontend/src/quizData.ts
@@ -1,0 +1,33 @@
+export interface Question {
+  question: string;
+  options: string[];
+  answer: number; // index of correct option
+}
+
+export const quiz: Question[] = [
+  {
+    question: "What is 2 + 2?",
+    options: ["3", "4", "5", "6"],
+    answer: 1,
+  },
+  {
+    question: "Which planet is known as the Red Planet?",
+    options: ["Earth", "Mars", "Jupiter", "Venus"],
+    answer: 1,
+  },
+  {
+    question: 'Who wrote "To Kill a Mockingbird"?',
+    options: ["Harper Lee", "Mark Twain", "J.K. Rowling", "Ernest Hemingway"],
+    answer: 0,
+  },
+  {
+    question: "What is the boiling point of water?",
+    options: ["90°C", "100°C", "80°C", "120°C"],
+    answer: 1,
+  },
+  {
+    question: "Which language runs in a web browser?",
+    options: ["Python", "Java", "C", "JavaScript"],
+    answer: 3,
+  },
+];

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize frontend React app structure with Vite config and tsconfig
- implement Home, Quiz and Result pages with react-router
- add static quiz questions for the prototype
- ignore build artifacts and Python caches

## Testing
- `pytest -q`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b109d63488324884d690f210092f9