### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,1 +1,25 @@
-# TODO: Add deployment workflow
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+        working-directory: frontend
+      - run: npm run build
+        working-directory: frontend
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: frontend/dist
+

--- a/README.md
+++ b/README.md
@@ -26,3 +26,16 @@ history storage.
    cd frontend
    npm install
    ```
+
+## Deploying to GitHub Pages
+
+1. Make sure the `base` option in `frontend/vite.config.ts` matches your
+   repository name. For this project it is set to `/learning-quiz-ai/`.
+2. Build and publish the site:
+   ```bash
+   cd frontend
+   npm run deploy
+   ```
+   The command uses [gh-pages](https://github.com/tschaub/gh-pages) to push the
+   contents of the `dist` folder to the `gh-pages` branch so it can be served on
+   GitHub Pages.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "react": "^18.0.0",
@@ -15,6 +17,7 @@
   "devDependencies": {
     "vite": "^4.0.0",
     "@vitejs/plugin-react": "^4.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "gh-pages": "^5.0.0"
   }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,4 +3,6 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  // Base path needed for GitHub Pages deployment
+  base: "/learning-quiz-ai/",
 });


### PR DESCRIPTION
## Summary
- configure Vite with a base path for GitHub Pages
- add deploy scripts and gh-pages dependency
- document deployment steps in README
- add GitHub Actions workflow to publish the frontend

## Testing
- `pytest -q`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1470ddd48324a0a1e8674c3a7127