### PR TITLE
Fix gh-pages deployment permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- grant write permissions on contents for the deploy job

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c44cc0d8c83248fcb2b205efcfca0