### PR TITLE
Fix GitHub Pages routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import "./App.css";
 
 export default function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/quiz" element={<Quiz />} />


### PR DESCRIPTION
## Summary
- ensure React Router works correctly on GitHub Pages by using `basename`

## Testing
- `pytest`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c55f8eea48324af40bf33a52ffcab