### PR TITLE
Store API key in cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ history storage.
 The production build can be tested with `npm run build` followed by
 `npm run preview`.
 
+### Using your OpenAI API key
+
+When starting the app, you will be asked for your OpenAI API key on the home
+page. The key is stored in a browser cookie named `openai_key` that expires
+after seven days. This is intended for local development only and is not
+recommended for production use.
+
 ## Deploying to GitHub Pages
 
 1. Make sure the `base` option in `frontend/vite.config.ts` matches your

--- a/frontend/src/cookies.ts
+++ b/frontend/src/cookies.ts
@@ -1,0 +1,14 @@
+export function setCookie(name: string, value: string, days: number) {
+  const expires = new Date(Date.now() + days * 864e5).toUTCString();
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+}
+
+export function getCookie(name: string): string | null {
+  const cookies = document.cookie.split(';').map(c => c.trim());
+  for (const c of cookies) {
+    if (c.startsWith(`${name}=`)) {
+      return decodeURIComponent(c.substring(name.length + 1));
+    }
+  }
+  return null;
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,11 +1,14 @@
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
+import { setCookie, getCookie } from "../cookies";
 
 export default function Home() {
   const [url, setUrl] = useState("");
+  const [apiKey, setApiKey] = useState(getCookie("openai_key") || "");
   const navigate = useNavigate();
 
   const handleStart = () => {
+    setCookie("openai_key", apiKey, 7);
     navigate("/quiz");
   };
 
@@ -17,6 +20,12 @@ export default function Home() {
         placeholder="https://example.com/article"
         value={url}
         onChange={(e) => setUrl(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="OpenAI API Key"
+        value={apiKey}
+        onChange={(e) => setApiKey(e.target.value)}
       />
       <button onClick={handleStart}>Generate</button>
     </div>


### PR DESCRIPTION
## Summary
- add simple cookie helper in the frontend
- store OpenAI key in cookie on the home page
- document how the key is stored for development use

## Testing
- `pytest`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e986f2a883249e024793b96941e7