### PR TITLE
Prompt for API key before entering URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ The production build can be tested with `npm run build` followed by
 
 ### Using your OpenAI API key
 
-When starting the app, you will be asked for your OpenAI API key on the home
-page. The key is stored in a browser cookie named `openai_key` that expires
-after seven days. This is intended for local development only and is not
-recommended for production use.
+When opening the app for the first time you will be prompted to enter your
+OpenAI API key. The key is stored in a browser cookie named `openai_key` that
+expires after seven days. If the cookie already exists, you will skip the key
+prompt and can immediately provide a URL. This is intended for local
+development only and is not recommended for production use.
 
 ## Deploying to GitHub Pages
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -31,6 +31,15 @@ input[type="text"] {
   font-size: 16px;
 }
 
+input[type="password"] {
+  width: 100%;
+  padding: 10px;
+  border-radius: 8px;
+  border: none;
+  margin-top: 10px;
+  font-size: 16px;
+}
+
 button {
   width: 100%;
   margin-top: 20px;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,31 +3,52 @@ import { useState } from "react";
 import { setCookie, getCookie } from "../cookies";
 
 export default function Home() {
+  const storedKey = getCookie("openai_key") || "";
+  const [step, setStep] = useState(storedKey ? 2 : 1);
   const [url, setUrl] = useState("");
-  const [apiKey, setApiKey] = useState(getCookie("openai_key") || "");
+  const [apiKey, setApiKey] = useState(storedKey);
   const navigate = useNavigate();
 
-  const handleStart = () => {
+  const handleSaveKey = () => {
+    if (!apiKey) return;
     setCookie("openai_key", apiKey, 7);
+    setStep(2);
+  };
+
+  const handleStart = () => {
     navigate("/quiz");
   };
 
   return (
     <div className="container">
-      <h1>📚 Learn from any URL</h1>
-      <input
-        type="text"
-        placeholder="https://example.com/article"
-        value={url}
-        onChange={(e) => setUrl(e.target.value)}
-      />
-      <input
-        type="password"
-        placeholder="OpenAI API Key"
-        value={apiKey}
-        onChange={(e) => setApiKey(e.target.value)}
-      />
-      <button onClick={handleStart}>Generate</button>
+      {step === 1 && (
+        <>
+          <h1>Enter OpenAI API Key</h1>
+          <input
+            type="password"
+            placeholder="OpenAI API Key"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+          />
+          <button onClick={handleSaveKey} disabled={!apiKey}>
+            Continue
+          </button>
+        </>
+      )}
+      {step === 2 && (
+        <>
+          <h1>📚 Learn from any URL</h1>
+          <input
+            type="text"
+            placeholder="https://example.com/article"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+          <button onClick={handleStart} disabled={!url}>
+            Generate
+          </button>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- ask for API key first when not stored
- style password inputs
- document the new flow for the OpenAI API key

## Testing
- `pytest`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ec9c173c8324a478c4c6911a86c0