### PR TITLE
Implement OpenAI quiz generation API

### DIFF
--- a/backend/api/quiz.py
+++ b/backend/api/quiz.py
@@ -1,7 +1,13 @@
 from fastapi import APIRouter
 
+from ..models.quiz_models import QuizRequest, QuizResponse, QuizQuestion
+from ..services.quiz_generator import generate_quiz_from_url
+
 router = APIRouter()
 
-@router.get("/quiz")
-async def generate_quiz():
-    return {"quiz": []}
+
+@router.post("/quiz", response_model=QuizResponse)
+async def generate_quiz(req: QuizRequest) -> QuizResponse:
+    quiz_data = generate_quiz_from_url(req.api_key, req.url)
+    questions = [QuizQuestion(**q) for q in quiz_data]
+    return QuizResponse(questions=questions)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,12 @@
 from fastapi import FastAPI
 
+from .api import quiz
+
 app = FastAPI()
 
 @app.get("/")
 async def root():
     return {"message": "Welcome to Learning Quiz AI"}
+
+
+app.include_router(quiz.router)

--- a/backend/models/quiz_models.py
+++ b/backend/models/quiz_models.py
@@ -1,6 +1,17 @@
 from pydantic import BaseModel
 
+
+class QuizRequest(BaseModel):
+    """Parameters to generate a quiz from a URL."""
+
+    api_key: str
+    url: str
+
 class QuizQuestion(BaseModel):
     question: str
     options: list[str]
     answer: int
+
+
+class QuizResponse(BaseModel):
+    questions: list[QuizQuestion]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,6 @@
 fastapi
 openai
 httpx
+requests
+beautifulsoup4
 pytest

--- a/backend/services/quiz_generator.py
+++ b/backend/services/quiz_generator.py
@@ -1,3 +1,45 @@
-def generate_quiz_from_url(url: str):
-    """Placeholder for quiz generation logic"""
-    pass
+"""Utilities to create quizzes from web content using OpenAI."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import openai
+import requests
+from bs4 import BeautifulSoup
+
+
+PROMPT = (
+    "You are a helpful assistant that creates multiple choice quizzes from "
+    "website content. Use the provided text to generate exactly five questions "
+    "with four answer options each. Return the result strictly as JSON in the "
+    "following format: \n"
+    "[{'question': '...', 'options': ['A', 'B', 'C', 'D'], 'answer': 0}]"
+    " where 'answer' is the index of the correct option."
+)
+
+
+def _fetch_page_text(url: str) -> str:
+    """Return plain text content for the given URL."""
+    resp = requests.get(url)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    return soup.get_text(separator=" ", strip=True)
+
+
+def generate_quiz_from_url(api_key: str, url: str) -> list[dict[str, Any]]:
+    """Fetch the page and ask OpenAI to create quiz questions."""
+
+    text = _fetch_page_text(url)
+
+    openai.api_key = api_key
+    messages = [
+        {"role": "system", "content": "You generate quizzes from website content."},
+        {"role": "user", "content": f"{PROMPT}\nContent:\n{text}"},
+    ]
+
+    completion = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
+    content = completion.choices[0].message.content
+    return json.loads(content)
+

--- a/backend/tests/test_quiz.py
+++ b/backend/tests/test_quiz.py
@@ -1,2 +1,25 @@
-def test_placeholder():
-    assert True
+from fastapi.testclient import TestClient
+
+from ..main import app
+from ..services import quiz_generator
+
+
+client = TestClient(app)
+
+
+def test_generate_quiz_endpoint(monkeypatch):
+    sample = [
+        {"question": "q1", "options": ["a", "b", "c", "d"], "answer": 0}
+        for _ in range(5)
+    ]
+
+    def mock_generate(api_key: str, url: str):
+        assert api_key == "key"
+        assert url == "http://example.com"
+        return sample
+
+    monkeypatch.setattr(quiz_generator, "generate_quiz_from_url", mock_generate)
+
+    response = client.post("/quiz", json={"api_key": "key", "url": "http://example.com"})
+    assert response.status_code == 200
+    assert response.json() == {"questions": sample}

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,6 @@ dependencies:
       - fastapi
       - openai
       - httpx
+      - requests
+      - beautifulsoup4
       - pytest


### PR DESCRIPTION
## Summary
- implement OpenAI-powered quiz generation service
- add POST /quiz endpoint returning generated questions
- wire quiz router into FastAPI app
- expand quiz models
- create tests for new endpoint
- include new dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862f174a0e8832489acb0457be26889