### PR TITLE
Integrate backend quiz generation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,17 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from .api import quiz
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get("/")
 async def root():

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -15,8 +15,14 @@ export default function Home() {
     setStep(2);
   };
 
-  const handleStart = () => {
-    navigate("/quiz");
+  const handleStart = async () => {
+    const response = await fetch("http://localhost:8000/quiz", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ api_key: apiKey, url }),
+    });
+    const data = await response.json();
+    navigate("/quiz", { state: { quiz: data.questions } });
   };
 
   return (

--- a/frontend/src/pages/Quiz.tsx
+++ b/frontend/src/pages/Quiz.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { quiz } from "../quizData";
+import { useNavigate, useLocation } from "react-router-dom";
+import { Question } from "../quizData";
 
 export default function Quiz() {
+  const { state } = useLocation() as { state: { quiz: Question[] } };
+  const quiz = state?.quiz || [];
   const [step, setStep] = useState(0);
   const [answers, setAnswers] = useState<number[]>([]);
   const [choice, setChoice] = useState<number | null>(null);
@@ -18,7 +20,7 @@ export default function Quiz() {
     if (step + 1 < quiz.length) {
       setStep(step + 1);
     } else {
-      navigate("/result", { state: { answers: newAnswers } });
+      navigate("/result", { state: { answers: newAnswers, quiz } });
     }
   };
 

--- a/frontend/src/pages/Result.tsx
+++ b/frontend/src/pages/Result.tsx
@@ -1,14 +1,16 @@
 import { useLocation, useNavigate } from "react-router-dom";
-import { quiz } from "../quizData";
+import { Question } from "../quizData";
 
 interface LocationState {
   answers: number[];
+  quiz: Question[];
 }
 
 export default function Result() {
   const navigate = useNavigate();
   const { state } = useLocation() as { state: LocationState };
   const answers = state?.answers || [];
+  const quiz = state?.quiz || [];
 
   const score = answers.reduce(
     (acc, ans, idx) => (ans === quiz[idx].answer ? acc + 1 : acc),


### PR DESCRIPTION
## Summary
- enable CORS in FastAPI backend
- fetch quiz data from backend in Home page
- display quiz questions from returned data
- show results for the fetched quiz

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f7c6ded083249bc2043289926e68