### PR TITLE
Fix backend URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ history storage.
    cd frontend
    npm install
    ```
-3. Start the development server:
+3. Configure the backend URL by creating a `.env` file in the `frontend`
+   directory:
+   ```bash
+   echo "VITE_API_URL=http://localhost:8000" > .env
+   ```
+   Adjust the URL if your FastAPI server runs elsewhere.
+4. Start the development server:
    ```bash
    npm run dev
    ```

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -16,10 +16,12 @@ export default function Home() {
     setStep(2);
   };
 
+  const API_BASE = import.meta.env.VITE_API_URL || "";
+
   const handleStart = async () => {
     setError("");
     try {
-      const response = await fetch("http://localhost:8000/quiz", {
+      const response = await fetch(`${API_BASE}/quiz`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ api_key: apiKey, url }),


### PR DESCRIPTION
## Summary
- allow configuring backend via `VITE_API_URL`
- document `.env` setup in the README
- add default API URL for local development

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fdde6ff48324878bbce9043e8c03