### PR TITLE
Remove gh-pages deployment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,3 @@ expires after seven days. If the cookie already exists, you will skip the key
 prompt and can immediately provide a URL. This is intended for local
 development only and is not recommended for production use.
 
-## Deploying to GitHub Pages
-
-1. Make sure the `base` option in `frontend/vite.config.ts` matches your
-   repository name. For this project it is set to `/website_learner/`.
-2. Build and publish the site:
-   ```bash
-   cd frontend
-   npm run deploy
-   ```
-   The command uses [gh-pages](https://github.com/tschaub/gh-pages) to push the
-   contents of the `dist` folder to the `gh-pages` branch so it can be served on
-   GitHub Pages.
-
-   Once published, your site will be available at:
-   `https://<your-github-username>.github.io/website_learner/`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,9 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^18.0.0",
@@ -17,7 +15,6 @@
   "devDependencies": {
     "vite": "^4.0.0",
     "@vitejs/plugin-react": "^4.0.0",
-    "typescript": "^5.0.0",
-    "gh-pages": "^5.0.0"
+    "typescript": "^5.0.0"
   }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig(({ command }) => ({
+export default defineConfig({
   plugins: [react()],
-  // Use GitHub Pages base path only for the production build
-  base: command === "build" ? "/website_learner/" : "/",
-}));
+  base: "/",
+});


### PR DESCRIPTION
## Summary
- remove GitHub Pages scripts and dependency
- simplify `vite.config.ts` so `base` is always `/`
- drop GitHub Pages instructions from the README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683a0b9ea08324a314375fc7468c42