### PR TITLE
Make API key optional

### DIFF
--- a/backend/api/quiz.py
+++ b/backend/api/quiz.py
@@ -8,6 +8,6 @@ router = APIRouter()
 
 @router.post("/quiz", response_model=QuizResponse)
 async def generate_quiz(req: QuizRequest) -> QuizResponse:
-    quiz_data = generate_quiz_from_url(req.api_key, req.url)
+    quiz_data = generate_quiz_from_url(req.url)
     questions = [QuizQuestion(**q) for q in quiz_data]
     return QuizResponse(questions=questions)

--- a/backend/models/quiz_models.py
+++ b/backend/models/quiz_models.py
@@ -4,8 +4,8 @@ from pydantic import BaseModel
 class QuizRequest(BaseModel):
     """Parameters to generate a quiz from a URL."""
 
-    api_key: str
     url: str
+    api_key: str | None = None
 
 class QuizQuestion(BaseModel):
     question: str

--- a/backend/services/quiz_generator.py
+++ b/backend/services/quiz_generator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
 
 import openai
@@ -28,12 +29,12 @@ def _fetch_page_text(url: str) -> str:
     return soup.get_text(separator=" ", strip=True)
 
 
-def generate_quiz_from_url(api_key: str, url: str) -> list[dict[str, Any]]:
+def generate_quiz_from_url(url: str, api_key: str | None = None) -> list[dict[str, Any]]:
     """Fetch the page and ask OpenAI to create quiz questions."""
 
     text = _fetch_page_text(url)
 
-    openai.api_key = api_key
+    openai.api_key = api_key or os.environ.get("OPENAI_API_KEY")
     messages = [
         {"role": "system", "content": "You generate quizzes from website content."},
         {"role": "user", "content": f"{PROMPT}\nContent:\n{text}"},

--- a/backend/tests/test_quiz.py
+++ b/backend/tests/test_quiz.py
@@ -13,13 +13,14 @@ def test_generate_quiz_endpoint(monkeypatch):
         for _ in range(5)
     ]
 
-    def mock_generate(api_key: str, url: str):
-        assert api_key == "key"
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+
+    def mock_generate(url: str, api_key: str | None = None):
         assert url == "http://example.com"
         return sample
 
     monkeypatch.setattr(quiz_generator, "generate_quiz_from_url", mock_generate)
 
-    response = client.post("/quiz", json={"api_key": "key", "url": "http://example.com"})
+    response = client.post("/quiz", json={"url": "http://example.com"})
     assert response.status_code == 200
     assert response.json() == {"questions": sample}


### PR DESCRIPTION
## Summary
- make `api_key` optional in `QuizRequest`
- default to `OPENAI_API_KEY` in generator if not provided
- adjust API router accordingly
- update tests for optional key usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68683a0c8bd4832499e5bc618dd8bf32