### PR TITLE
Implement Supabase client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ history storage.
    conda env create -f environment.yml
    conda activate website_learner
    ```
-3. Run tests:
+3. Install the Supabase client library:
+   ```bash
+   pip install supabase
+   ```
+4. Configure Supabase connection settings by defining the `SUPABASE_URL` and
+   `SUPABASE_API_KEY` environment variables.
+5. Run tests:
    ```bash
    pytest
    ```

--- a/backend/db/supabase_client.py
+++ b/backend/db/supabase_client.py
@@ -1,4 +1,13 @@
-# Initialize later
+"""Supabase client initialization."""
 
-# Placeholder for Supabase client
-supabase = None
+import os
+
+from supabase import create_client, Client
+
+# Pull connection info from the environment
+url: str = os.environ["SUPABASE_URL"]
+api_key: str = os.environ["SUPABASE_API_KEY"]
+
+# Export a configured client instance for use in the app
+supabase: Client = create_client(url, api_key)
+


### PR DESCRIPTION
## Summary
- initialize Supabase client using environment variables
- document Supabase setup in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68683a0eb86883249b292e0ec962f9b0