### PR TITLE
Fix relative imports by adding package init files

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,1 @@
+# Package init


### PR DESCRIPTION
## Summary
- initialize backend modules so Python treats them as packages
- add basic placeholders to the init modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6868434972408324a1f4d38d24a2a6c9