### PR TITLE
Fix missing uvicorn dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,4 +3,5 @@ openai
 httpx
 requests
 beautifulsoup4
+uvicorn
 pytest

--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,5 @@ dependencies:
       - httpx
       - requests
       - beautifulsoup4
+      - uvicorn
       - pytest


### PR DESCRIPTION
## Summary
- include `uvicorn` in backend requirements
- include `uvicorn` in conda environment spec

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686846aa33a8832499be72caf2fa8a1e