### PR TITLE
Switch quiz generator to httpx

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,6 @@
 fastapi
 openai
 httpx
-requests
 beautifulsoup4
 uvicorn
 pytest

--- a/backend/services/quiz_generator.py
+++ b/backend/services/quiz_generator.py
@@ -7,7 +7,7 @@ import os
 from typing import Any
 
 import openai
-import requests
+import httpx
 from bs4 import BeautifulSoup
 
 
@@ -23,7 +23,7 @@ PROMPT = (
 
 def _fetch_page_text(url: str) -> str:
     """Return plain text content for the given URL."""
-    resp = requests.get(url)
+    resp = httpx.get(url)
     resp.raise_for_status()
     soup = BeautifulSoup(resp.text, "html.parser")
     return soup.get_text(separator=" ", strip=True)

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,6 @@ dependencies:
       - fastapi
       - openai
       - httpx
-      - requests
       - beautifulsoup4
       - uvicorn
       - pytest


### PR DESCRIPTION
## Summary
- remove `requests` as a dependency
- replace usage of `requests` with `httpx`
- update requirement files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` in `frontend` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686848674f1883248d94d23ee45c4ffb