### PR TITLE
Fix CORS by proxying API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ history storage.
    npm install
    ```
 3. Configure the backend URL by creating a `.env` file in the `frontend`
-   directory. The frontend expects the `VITE_API_URL` variable to point to
-   your running FastAPI server:
+   directory. Set `VITE_API_URL` to the address of your FastAPI server.
+   During development the Vite dev server proxies `/api` requests to this
+   URL so the frontend can make relative API calls:
    ```bash
    echo "VITE_API_URL=http://localhost:8000" > .env
    ```

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -6,7 +6,7 @@ export default function Home() {
   const navigate = useNavigate();
   const [error, setError] = useState("");
 
-  const API_BASE = import.meta.env.VITE_API_URL || "";
+  const API_BASE = import.meta.env.VITE_API_URL || "/api";
 
   const handleStart = async () => {
     setError("");

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,20 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  plugins: [react()],
-  base: "/",
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const target = env.VITE_API_URL || "http://localhost:8000";
+  return {
+    plugins: [react()],
+    base: "/",
+    server: {
+      proxy: {
+        "/api": {
+          target,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, ""),
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- use `/api` for quiz requests by default
- proxy `/api` to the backend in Vite config
- clarify environment variable usage in README

## Testing
- `npm run build` *(fails: vite not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68684ad4dff88324926b562844ea0df5