### PR TITLE
Support quiz length and multiple-answer questions

### DIFF
--- a/backend/api/quiz.py
+++ b/backend/api/quiz.py
@@ -8,6 +8,8 @@ router = APIRouter()
 
 @router.post("/quiz", response_model=QuizResponse)
 async def generate_quiz(req: QuizRequest) -> QuizResponse:
-    quiz_data = generate_quiz_from_url(req.url)
+    quiz_data = generate_quiz_from_url(
+        req.url, num_questions=req.num_questions, allow_multiple=req.allow_multiple
+    )
     questions = [QuizQuestion(**q) for q in quiz_data]
     return QuizResponse(questions=questions)

--- a/backend/models/quiz_models.py
+++ b/backend/models/quiz_models.py
@@ -1,15 +1,18 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class QuizRequest(BaseModel):
     """Parameters to generate a quiz from a URL."""
 
     url: str
+    num_questions: int = Field(5, ge=3, le=6)
+    allow_multiple: bool = False
 
 class QuizQuestion(BaseModel):
     question: str
     options: list[str]
-    answer: int
+    answers: list[int]
+    multiple: bool
 
 
 class QuizResponse(BaseModel):

--- a/backend/services/quiz_generator.py
+++ b/backend/services/quiz_generator.py
@@ -29,17 +29,37 @@ def _fetch_page_text(url: str) -> str:
     return soup.get_text(separator=" ", strip=True)
 
 
-def generate_quiz_from_url(url: str) -> list[dict[str, Any]]:
+def generate_quiz_from_url(
+    url: str, num_questions: int = 5, allow_multiple: bool = False
+) -> list[dict[str, Any]]:
+    """Generate a quiz using OpenAI from the given URL."""
+
     client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
     text_content = _fetch_page_text(url)
     
     chat_response = client.chat.completions.create(
         model="gpt-4o",
         messages=[
-            {"role": "system", "content": "You generate multiple-choice quizzes from website content."},
-            {"role": "user", "content": f"You are a helpful assistant that creates multiple choice quizzes from website content. Use the provided text to generate exactly five questions with four answer options each. Return the result strictly as JSON in the following format: [{{'question': '...', 'options': ['A', 'B', 'C', 'D'], 'answer': 0}}]  where 'answer' is the index of the correct option. Please quiz have to be in german! \n\n. Here is the text fo the website to analyze: {text_content[:4000]}\n\n"}
+            {
+                "role": "system",
+                "content": "You generate multiple-choice quizzes from website content.",
+            },
+            {
+                "role": "user",
+                "content": (
+                    "You are a helpful assistant that creates multiple choice quizzes from website content. "
+                    f"Use the provided text to generate exactly {num_questions} questions with four answer options each. "
+                    "If the allow-multiple flag is true you may include questions with several correct answers. "
+                    "Return strictly JSON in the following format: "
+                    "[{'question': '...', 'options': ['A', 'B', 'C', 'D'], 'answers': [0, 2], 'multiple': true}] "
+                    "where 'multiple' indicates if more than one option is correct. "
+                    "Please respond in German!\n\n"
+                    f"allow-multiple: {allow_multiple}\n"
+                    f"Here is the website text: {text_content[:4000]}\n\n"
+                ),
+            },
         ],
-        temperature=0.7
+        temperature=0.7,
     )
     content = chat_response.choices[0].message.content
     content = content.replace("```json","")

--- a/backend/tests/test_quiz.py
+++ b/backend/tests/test_quiz.py
@@ -9,14 +9,21 @@ client = TestClient(app)
 
 def test_generate_quiz_endpoint(monkeypatch):
     sample = [
-        {"question": "q1", "options": ["a", "b", "c", "d"], "answer": 0}
+        {
+            "question": "q1",
+            "options": ["a", "b", "c", "d"],
+            "answers": [0],
+            "multiple": False,
+        }
         for _ in range(5)
     ]
 
     monkeypatch.setenv("OPENAI_API_KEY", "key")
 
-    def mock_generate(url: str):
+    def mock_generate(url: str, num_questions: int = 5, allow_multiple: bool = False):
         assert url == "http://example.com"
+        assert num_questions == 5
+        assert allow_multiple is False
         return sample
 
     monkeypatch.setattr(quiz_generator, "generate_quiz_from_url", mock_generate)

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 
 export default function Home() {
   const [url, setUrl] = useState("");
+  const [numQuestions, setNumQuestions] = useState(5);
+  const [allowMultiple, setAllowMultiple] = useState(false);
   const navigate = useNavigate();
   const [error, setError] = useState("");
 
@@ -14,7 +16,11 @@ export default function Home() {
       const response = await fetch(`${API_BASE}/quiz`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url }),
+        body: JSON.stringify({
+          url,
+          num_questions: numQuestions,
+          allow_multiple: allowMultiple,
+        }),
       });
       if (!response.ok) {
         const text = await response.text();
@@ -41,6 +47,24 @@ export default function Home() {
         value={url}
         onChange={(e) => setUrl(e.target.value)}
       />
+      <label>
+        Number of questions:
+        <input
+          type="number"
+          min={3}
+          max={6}
+          value={numQuestions}
+          onChange={(e) => setNumQuestions(parseInt(e.target.value, 10))}
+        />
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={allowMultiple}
+          onChange={(e) => setAllowMultiple(e.target.checked)}
+        />
+        Allow multiple answers
+      </label>
       <button onClick={handleStart} disabled={!url}>
         Generate
       </button>

--- a/frontend/src/pages/Quiz.tsx
+++ b/frontend/src/pages/Quiz.tsx
@@ -6,17 +6,28 @@ export default function Quiz() {
   const { state } = useLocation() as { state: { quiz: Question[] } };
   const quiz = state?.quiz || [];
   const [step, setStep] = useState(0);
-  const [answers, setAnswers] = useState<number[]>([]);
-  const [choice, setChoice] = useState<number | null>(null);
+  const [answers, setAnswers] = useState<number[][]>([]);
+  const [choice, setChoice] = useState<number[]>([]);
   const navigate = useNavigate();
 
   const question = quiz[step];
+  const toggleChoice = (idx: number) => {
+    setChoice((prev) =>
+      prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]
+    );
+  };
 
   const handleNext = () => {
-    if (choice === null) return;
+    const question = quiz[step];
+    if (question.multiple) {
+      if (choice.length === 0) return;
+    } else {
+      if (choice.length !== 1) return;
+    }
+
     const newAnswers = [...answers, choice];
     setAnswers(newAnswers);
-    setChoice(null);
+    setChoice([]);
     if (step + 1 < quiz.length) {
       setStep(step + 1);
     } else {
@@ -35,10 +46,16 @@ export default function Quiz() {
           <li key={idx} style={{ marginBottom: "8px" }}>
             <label>
               <input
-                type="radio"
+                type={question.multiple ? "checkbox" : "radio"}
                 name="option"
-                checked={choice === idx}
-                onChange={() => setChoice(idx)}
+                checked={
+                  question.multiple ? choice.includes(idx) : choice[0] === idx
+                }
+                onChange={() =>
+                  question.multiple
+                    ? toggleChoice(idx)
+                    : setChoice([idx])
+                }
               />
               {opt}
             </label>

--- a/frontend/src/pages/Result.tsx
+++ b/frontend/src/pages/Result.tsx
@@ -2,7 +2,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { Question } from "../quizData";
 
 interface LocationState {
-  answers: number[];
+  answers: number[][];
   quiz: Question[];
 }
 
@@ -12,10 +12,12 @@ export default function Result() {
   const answers = state?.answers || [];
   const quiz = state?.quiz || [];
 
-  const score = answers.reduce(
-    (acc, ans, idx) => (ans === quiz[idx].answer ? acc + 1 : acc),
-    0,
-  );
+  const score = answers.reduce((acc, ans, idx) => {
+    const correct = quiz[idx].answers;
+    const isCorrect =
+      ans.length === correct.length && ans.every((i) => correct.includes(i));
+    return isCorrect ? acc + 1 : acc;
+  }, 0);
 
   return (
     <div className="container">
@@ -23,16 +25,21 @@ export default function Result() {
         🎉 You scored {score} out of {quiz.length}!
       </h1>
       <ul>
-        {quiz.map((q, idx) => (
-          <li key={idx} style={{ marginBottom: "12px" }}>
-            <p>{q.question}</p>
-            <p>
-              {answers[idx] === q.answer ? "✔️" : "❌"} Correct:{" "}
-              {q.options[q.answer]} — Your answer:{" "}
-              {answers[idx] !== undefined ? q.options[answers[idx]] : "N/A"}
-            </p>
-          </li>
-        ))}
+        {quiz.map((q, idx) => {
+          const userAns = answers[idx] || [];
+          const isCorrect =
+            userAns.length === q.answers.length &&
+            userAns.every((i) => q.answers.includes(i));
+          return (
+            <li key={idx} style={{ marginBottom: "12px" }}>
+              <p>{q.question}</p>
+              <p>
+                {isCorrect ? "✔️" : "❌"} Correct: {q.answers.map((i) => q.options[i]).join(", ")} —
+                Your answer: {userAns.length ? userAns.map((i) => q.options[i]).join(", ") : "N/A"}
+              </p>
+            </li>
+          );
+        })}
       </ul>
       <button onClick={() => navigate("/")}>Try Another URL</button>
     </div>

--- a/frontend/src/quizData.ts
+++ b/frontend/src/quizData.ts
@@ -1,33 +1,39 @@
 export interface Question {
   question: string;
   options: string[];
-  answer: number; // index of correct option
+  answers: number[]; // indices of correct options
+  multiple: boolean;
 }
 
 export const quiz: Question[] = [
   {
     question: "What is 2 + 2?",
     options: ["3", "4", "5", "6"],
-    answer: 1,
+    answers: [1],
+    multiple: false,
   },
   {
     question: "Which planet is known as the Red Planet?",
     options: ["Earth", "Mars", "Jupiter", "Venus"],
-    answer: 1,
+    answers: [1],
+    multiple: false,
   },
   {
     question: 'Who wrote "To Kill a Mockingbird"?',
     options: ["Harper Lee", "Mark Twain", "J.K. Rowling", "Ernest Hemingway"],
-    answer: 0,
+    answers: [0],
+    multiple: false,
   },
   {
     question: "What is the boiling point of water?",
     options: ["90°C", "100°C", "80°C", "120°C"],
-    answer: 1,
+    answers: [1],
+    multiple: false,
   },
   {
     question: "Which language runs in a web browser?",
     options: ["Python", "Java", "C", "JavaScript"],
-    answer: 3,
+    answers: [3],
+    multiple: false,
   },
 ];


### PR DESCRIPTION
## Summary
- allow selecting number of questions and multiple-answer mode via API
- update quiz models to store multiple answers
- extend quiz generator to accept new arguments
- update frontend to send new options and display checkboxes for multi-answer
- adjust result scoring logic
- update tests for new protocol

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699613a0c88324a81f89b0c4a36a18