### PR TITLE
Remove unused quiz helper

### DIFF
--- a/backend/services/quiz_generator.py
+++ b/backend/services/quiz_generator.py
@@ -11,16 +11,6 @@ import httpx
 from bs4 import BeautifulSoup
 
 
-PROMPT = (
-    "You are a helpful assistant that creates multiple choice quizzes from "
-    "website content. Use the provided text to generate exactly five questions "
-    "with four answer options each. Return the result strictly as JSON in the "
-    "following format: \n"
-    "[{'question': '...', 'options': ['A', 'B', 'C', 'D'], 'answer': 0}]"
-    " where 'answer' is the index of the correct option."
-)
-
-
 def _fetch_page_text(url: str) -> str:
     """Return plain text content for the given URL."""
     resp = httpx.get(url)
@@ -68,21 +58,5 @@ def generate_quiz_from_url(
     print("-----------")
     print(content)
     print("-----------")
-    return json.loads(content)
-    
-
-def generate_quiz_from_url2(url: str) -> list[dict[str, Any]]:
-    """Fetch the page and ask OpenAI to create quiz questions."""
-
-    text = _fetch_page_text(url)
-
-    openai.api_key = os.environ.get("OPENAI_API_KEY")
-    messages = [
-        {"role": "system", "content": "You generate quizzes from website content."},
-        {"role": "user", "content": f"{PROMPT}\nContent:\n{text}"},
-    ]
-
-    completion = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
-    content = completion.choices[0].message.content
     return json.loads(content)
 


### PR DESCRIPTION
## Summary
- delete legacy `generate_quiz_from_url2` function and `PROMPT` constant
- clean up trailing whitespace

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686999ff7e208324aa0bc09703b5e3c6