### PR TITLE
Add request logging middleware

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,21 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from .api import quiz
 
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 app = FastAPI()
+
+
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    logger.info("Incoming request: %s %s", request.method, request.url.path)
+    response = await call_next(request)
+    return response
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- log every incoming request in the FastAPI server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68696f96e1f08324a6a8d17804c8b25e