### PR TITLE
Implement user management API

### DIFF
--- a/backend/api/user.py
+++ b/backend/api/user.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+import secrets
+
+router = APIRouter()
+
+# In-memory storage for users and active tokens
+user_db: dict[str, str] = {}
+active_tokens: dict[str, str] = {}
+
+
+class Credentials(BaseModel):
+    email: str
+    password: str
+
+
+class Token(BaseModel):
+    token: str
+
+
+class UserList(BaseModel):
+    users: list[str]
+
+
+@router.post("/register")
+async def register(creds: Credentials) -> dict[str, str]:
+    if creds.email in user_db:
+        raise HTTPException(status_code=400, detail="User already exists")
+    user_db[creds.email] = creds.password
+    return {"message": "registered"}
+
+
+@router.post("/login", response_model=Token)
+async def login(creds: Credentials) -> Token:
+    if user_db.get(creds.email) != creds.password:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = secrets.token_urlsafe(16)
+    active_tokens[token] = creds.email
+    return Token(token=token)
+
+
+@router.post("/logout")
+async def logout(t: Token) -> dict[str, str]:
+    active_tokens.pop(t.token, None)
+    return {"message": "logged out"}
+
+
+@router.delete("/users/{email}")
+async def delete_user(email: str) -> dict[str, str]:
+    if email not in user_db:
+        raise HTTPException(status_code=404, detail="User not found")
+    del user_db[email]
+    for tok, em in list(active_tokens.items()):
+        if em == email:
+            del active_tokens[tok]
+    return {"message": "deleted"}
+
+
+@router.get("/users", response_model=UserList)
+async def list_users() -> UserList:
+    return UserList(users=list(user_db.keys()))

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .api import quiz
+from .api import quiz, user
 
 app = FastAPI()
 
@@ -19,3 +19,4 @@ async def root():
 
 
 app.include_router(quiz.router)
+app.include_router(user.router)

--- a/backend/tests/test_user.py
+++ b/backend/tests/test_user.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+
+from ..main import app
+from ..api import user
+
+client = TestClient(app)
+
+
+def setup_function(function):
+    user.user_db.clear()
+    user.active_tokens.clear()
+
+
+def test_user_flow():
+    # register
+    resp = client.post("/register", json={"email": "test@example.com", "password": "secret"})
+    assert resp.status_code == 200
+
+    # login
+    resp = client.post("/login", json={"email": "test@example.com", "password": "secret"})
+    assert resp.status_code == 200
+    token = resp.json()["token"]
+    assert token
+
+    # list
+    resp = client.get("/users")
+    assert resp.status_code == 200
+    assert "test@example.com" in resp.json()["users"]
+
+    # logout
+    resp = client.post("/logout", json={"token": token})
+    assert resp.status_code == 200
+
+    # delete
+    resp = client.delete("/users/test@example.com")
+    assert resp.status_code == 200
+    resp = client.get("/users")
+    assert "test@example.com" not in resp.json()["users"]
+
+
+def test_login_failure():
+    client.post("/register", json={"email": "foo@bar.com", "password": "pw"})
+    resp = client.post("/login", json={"email": "foo@bar.com", "password": "wrong"})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add `user` router with register/login/logout/delete/list endpoints
- include user router in FastAPI app
- add tests for user router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686aa7d5f7d88324a612fd71e0fb528f