### PR TITLE
Add auth context for storing token

### DIFF
--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useContext, useState } from "react";
+
+interface AuthContextType {
+  token: string | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  authFetch: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(() =>
+    localStorage.getItem("token")
+  );
+
+  const API_BASE = import.meta.env.VITE_API_URL || "/api";
+
+  const login = async (email: string, password: string) => {
+    const resp = await fetch(`${API_BASE}/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    if (!resp.ok) {
+      throw new Error(await resp.text());
+    }
+    const data: { token: string } = await resp.json();
+    setToken(data.token);
+    localStorage.setItem("token", data.token);
+  };
+
+  const logout = async () => {
+    if (token) {
+      await fetch(`${API_BASE}/logout`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      }).catch(() => {});
+    }
+    setToken(null);
+    localStorage.removeItem("token");
+  };
+
+  const authFetch = async (
+    input: RequestInfo,
+    init: RequestInit = {}
+  ): Promise<Response> => {
+    const headers = new Headers(init.headers);
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+    return fetch(input, { ...init, headers });
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout, authFetch }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextType {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return ctx;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { AuthProvider } from "./auth";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>,
 );

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, Link } from "react-router-dom";
 import { useState } from "react";
+import { useAuth } from "../auth";
 
 export default function Home() {
   const [url, setUrl] = useState("");
@@ -7,13 +8,13 @@ export default function Home() {
   const [allowMultiple, setAllowMultiple] = useState(false);
   const navigate = useNavigate();
   const [error, setError] = useState("");
-
+  const { authFetch } = useAuth();
   const API_BASE = import.meta.env.VITE_API_URL || "/api";
 
   const handleStart = async () => {
     setError("");
     try {
-      const response = await fetch(`${API_BASE}/quiz`, {
+      const response = await authFetch(`${API_BASE}/quiz`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,27 +1,18 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useAuth } from "../auth";
 
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const navigate = useNavigate();
-
-  const API_BASE = import.meta.env.VITE_API_URL || "/api";
+  const { login } = useAuth();
 
   const handleLogin = async () => {
     setError("");
     try {
-      const response = await fetch(`${API_BASE}/login`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, password }),
-      });
-      if (!response.ok) {
-        const text = await response.text();
-        setError(`Error ${response.status}: ${text}`);
-        return;
-      }
+      await login(email, password);
       navigate("/home");
     } catch (err) {
       if (err instanceof Error) {

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,18 +1,19 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useAuth } from "../auth";
 
 export default function Register() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const navigate = useNavigate();
-
+  const { authFetch } = useAuth();
   const API_BASE = import.meta.env.VITE_API_URL || "/api";
 
   const handleRegister = async () => {
     setError("");
     try {
-      const response = await fetch(`${API_BASE}/register`, {
+      const response = await authFetch(`${API_BASE}/register`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password }),


### PR DESCRIPTION
## Summary
- create `frontend/src/auth.tsx` with `AuthProvider` context
- wrap the app in `AuthProvider`
- use `login` helper in the login page
- use `authFetch` helper in register and home pages

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abbdae1bc8324938a12f7884c4847