### PR TITLE
Fix frontend Docker build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
 
   frontend:
     build:
-      context: .
-      dockerfile: frontend/Dockerfile
+      context: ./frontend
+      dockerfile: Dockerfile
       args:
         VITE_API_URL: http://backend:8000
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:18 AS build
 WORKDIR /app
-COPY frontend/package*.json ./
+COPY package*.json ./
 RUN npm install
-COPY frontend .
+COPY . .
 ARG VITE_API_URL=http://localhost:8000
 ENV VITE_API_URL=$VITE_API_URL
 RUN npm run build


### PR DESCRIPTION
## Summary
- fix `docker-compose` config so the frontend build uses `frontend` as the context
- update frontend Dockerfile to copy files from new context

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac2ff10cc8324bee932698b596809