### PR TITLE
Fix docker build issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   backend:
     build:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18 AS build
 WORKDIR /app
-COPY package*.json ./
-RUN npm install
+COPY package.json ./
+RUN npm install --legacy-peer-deps
 COPY . .
 ARG VITE_API_URL=http://localhost:8000
 ENV VITE_API_URL=$VITE_API_URL


### PR DESCRIPTION
## Summary
- update frontend Dockerfile copy command
- use `npm install --legacy-peer-deps`
- remove obsolete compose version

## Testing
- `npm run build` *(fails: vite not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686aca35df9c83249dc9119567fcfe42