### PR TITLE
Fix API URL for compose frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,10 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        VITE_API_URL: http://backend:8000
+        # The frontend communicates with the backend through the host
+        # mapped port, so use localhost instead of the Docker service
+        # name. This avoids DNS resolution errors in the browser.
+        VITE_API_URL: http://localhost:8000
     ports:
       - "5173:5173"
     depends_on:


### PR DESCRIPTION
## Summary
- use `http://localhost:8000` for the frontend build in `docker-compose.yml`
  so browsers can reach the API without DNS issues

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad187f85c83248d10889bdf737f72